### PR TITLE
Fix vulnerability reporting link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
 If you have found a vulnerability in ESPHome, please be sure to [responsibly disclose](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure)
-it to us by [reporting a vulnerability using GitHub’s Security Advisory](https://github.com/esphome/esphome/security/advisories/new).
+it to us by [reporting a vulnerability using GitHub’s Security Advisory](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
 
 **DO NOT MAKE A PUBLIC ISSUE FOR SECURITY VULNERABILITIES!**
 


### PR DESCRIPTION
Updated the link for reporting vulnerabilities to GitHub's documentation.