### PR TITLE
Point security reporters to repo-specific THREAT_MODEL.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,23 @@ but understand that ESPHome, like many open source projects, is relying heavily 
 volunteers that aren’t full-time resources. We may not be able to respond as quickly as you 
 would like due to other responsibilities.
 
+## CHECK THE THREAT MODEL FIRST
+
+Before reporting, please check whether the repository in question publishes a
+`THREAT_MODEL.md` and read it — it defines what is and isn't in scope for that
+project. At the time of writing, [esphome/esphome](https://github.com/esphome/esphome/blob/dev/THREAT_MODEL.md)
+and [esphome/device-builder](https://github.com/esphome/device-builder/blob/main/docs/THREAT_MODEL.md)
+have one.
+
+In particular, ESPHome treats anyone who can supply or edit a configuration as
+**trusted with full code execution on the host** — this is by design (for
+example, `external_components:` imports arbitrary Python, and the build toolchain
+shells out). Issues that only require the ability to edit a config — such as
+template/`${...}` substitution injection, `!include` / `packages:` /
+`dashboard_import:` behavior, or the validator crashing on hostile YAML — are
+therefore **not** vulnerabilities and do not need a private report. See the
+relevant `THREAT_MODEL.md` for the full rationale and the surface we do defend.
+
 ## SUPPORTED VERSIONS
 
 We only accept reports against the latest stable & official versions of ESPHome or any versions 


### PR DESCRIPTION
Adds a short "check the threat model first" section to the org-wide `SECURITY.md` (the default that renders at every repo's `/security/policy`).

We keep getting reports that boil down to "a config can run code on the host" (most recently a Jinja `${...}` substitution SSTI). That's not a vulnerability — ESPHome treats anyone who can supply or edit a config as trusted with full host code execution by design (`external_components:` imports arbitrary Python; the build toolchain shells out). This section tells reporters to read the relevant repository's `THREAT_MODEL.md` before filing, and spells out that config-write-only issues are out of scope.

Links the two threat models that currently exist:
- esphome/esphome (`THREAT_MODEL.md`) — added in esphome/esphome#17087
- esphome/device-builder (`docs/THREAT_MODEL.md`)

All existing policy text (90-day disclosure, supported versions, CVE criteria, bounties) is unchanged — this only inserts the new section.

> Note: the esphome/esphome link targets `dev/THREAT_MODEL.md`, which resolves once esphome/esphome#17087 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)